### PR TITLE
Setting: batteryinfo: Add config_show_battery_design_capacity & show_…

### DIFF
--- a/res/values/lineage_config.xml
+++ b/res/values/lineage_config.xml
@@ -35,6 +35,12 @@
     <!-- Show battery cycle count -->
     <bool name="config_show_battery_cycle_count" translatable="false">false</bool>
 
+    <!-- Show battery Design Capacity -->
+    <bool name="config_show_battery_design_capacity">true</bool>
+
+    <!-- Show battery Maximum Capacity -->
+    <bool name="config_show_battery_maximum_capacity">true</bool>
+
     <!-- Whether to show peak refresh rate in display settings -->
     <bool name="config_show_peak_refresh_rate_switch">false</bool>
 

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
@@ -35,7 +35,8 @@ public class BatteryDesignCapacityPreferenceController extends BasePreferenceCon
 
     @Override
     public int getAvailabilityStatus() {
-        return AVAILABLE;
+        boolean isFeatureEnabled = mContext.getResources().getBoolean(R.bool.config_show_battery_design_capacity);
+        return isFeatureEnabled ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
@@ -35,7 +35,8 @@ public class BatteryMaximumCapacityPreferenceController extends BasePreferenceCo
 
     @Override
     public int getAvailabilityStatus() {
-        return AVAILABLE;
+        boolean isFeatureEnabled = mContext.getResources().getBoolean(R.bool.config_show_battery_maximum_capacity);
+        return isFeatureEnabled ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override


### PR DESCRIPTION
…battery_maximum_capacity

* Legacy devices like the Pixel 2 Series do not support this feature, only show Unavailable for design capacity and maximum capacity in battery information.
* An alternative option if the device doesn't support it is just to add the config to disable this feature. 
* Enabled by default

Test: Build & flash