### PR TITLE
settings: Improve RAM summary formatting to show one decimal place

### DIFF
--- a/src/com/android/settings/deviceinfo/hardwareinfo/TotalRAMPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/hardwareinfo/TotalRAMPreferenceController.java
@@ -49,31 +49,17 @@ public class TotalRAMPreferenceController extends BasePreferenceController {
 
     @Override
     public CharSequence getSummary() {
-    ActivityManager actManager = (ActivityManager) mContext.getSystemService(Context.ACTIVITY_SERVICE);
-    ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
-    actManager.getMemoryInfo(memInfo);
-
-    long totRam = memInfo.totalMem;
-    double gb = (double) totRam / 1073741824.0;
-
-    String aproxRam;
-    if (gb > 0 && gb <= 2) {
-        aproxRam = "2";
-    } else if (gb <= 3) {
-        aproxRam = "3";
-    } else if (gb <= 4) {
-        aproxRam = "4";
-    } else if (gb <= 6) {
-        aproxRam = "6";
-    } else if (gb <= 8) {
-        aproxRam = "8";
-    } else if (gb <= 12) {
-        aproxRam = "12";
-    } else {
-        aproxRam = "12+";
+        ActivityManager actManager = (ActivityManager) mContext.getSystemService(Context.ACTIVITY_SERVICE);
+        ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
+        actManager.getMemoryInfo(memInfo);
+    
+        long totRam = memInfo.totalMem;
+        double gb = (double) totRam / 1073741824.0;
+    
+        // Format to show one decimal place
+        DecimalFormat df = new DecimalFormat("#.#");
+        String formattedRam = df.format(gb);
+        
+        return formattedRam + " GB";
     }
-
-    String actualRam = aproxRam.concat(" GB");
-    return actualRam;
-   }
 }


### PR DESCRIPTION
Unsure to why the previous implementation is done with this approxram method.

This way reports slightly under the "advertised amount" (22.7GB vs 24GB advertised), but that could be due to base10 gb vs base2 gb, reserved memory and other stuff. 

This code has been tested on my OnePlus 12, which I am building unoffically for. 