### PR TITLE
(fingerprint): guard against out-of-bounds access in getVendorString()

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1630,6 +1630,8 @@
     <!-- Packages that will not show Display over other apps permission -->
     <string-array name="display_over_apps_permission_change_exempt">
     </string-array>
-    <string-array name="fingerprint_acquired_vendor" />
+<string-array name="fingerprint_acquired_vendor">
+    <item>Fingerprint is immobile</item>
+</string-array>
 
 </resources>

--- a/src/com/android/settings/biometrics/fingerprint/feature/SfpsEnrollmentFeatureImpl.java
+++ b/src/com/android/settings/biometrics/fingerprint/feature/SfpsEnrollmentFeatureImpl.java
@@ -198,11 +198,18 @@ public class SfpsEnrollmentFeatureImpl implements SfpsEnrollmentFeature {
 
     private static final int VENDOR_STRING_FINGERPRINT_ACQUIRED_IMMOBILE = 0;
 
-    private static String getVendorString(Context ctx, int index) {
-        String[] strings = ctx.getResources().getStringArray(R.array.fingerprint_acquired_vendor);
-        Preconditions.checkArgumentInRange(index, 0, strings.length - 1, "vendor string index");
-        return strings[index];
+private static String getVendorString(Context ctx, int index) {
+    String[] strings = ctx.getResources().getStringArray(R.array.fingerprint_acquired_vendor);
+    if (strings == null || strings.length == 0) {
+        Log.e(TAG, "Vendor string array is null or empty");
+        return "";
     }
+    if (index < 0 || index >= strings.length) {
+        Log.e(TAG, "vendor string index is out of range: " + index + " (size: " + strings.length + ")");
+        return "";
+    }
+    return strings[index];
+}
 
     @Nullable
     private static IFingerprintExt getGoogleFingerprintExt() {


### PR DESCRIPTION
Add null and bounds checks to prevent crashes when accessing the fingerprint_acquired_vendor string array. This ensures safe fallback behavior and logs appropriate error messages when the index is invalid.

Also improves stability during enrollment help handling on Google devices.

05-23 22:59:15.144 11647 11647 E AndroidRuntime: FATAL EXCEPTION: main
05-23 22:59:15.144 11647 11647 E AndroidRuntime: Process: com.android.settings, PID: 11647
05-23 22:59:15.144 11647 11647 E AndroidRuntime: java.lang.IllegalArgumentException: vendor string index is out of range of [0, -1] (too high)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.settings.biometrics.fingerprint.feature.SfpsEnrollmentFeatureImpl.getVendorString(go/retraceme bb4a03fdc34cff7f722829db90aff515e0ae20b72b33e5004f74889672317151:33)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.settings.biometrics.fingerprint.feature.SfpsEnrollmentFeatureImpl.getFeaturedVendorString(go/retraceme bb4a03fdc34cff7f722829db90aff515e0ae20b72b33e5004f74889672317151:48)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.settings.biometrics.fingerprint.FingerprintEnrollEnrolling.onEnrollmentHelp(go/retraceme bb4a03fdc34cff7f722829db90aff515e0ae20b72b33e5004f74889672317151:7)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.settings.biometrics.BiometricEnrollSidecar.onEnrollmentHelp(go/retraceme bb4a03fdc34cff7f722829db90aff515e0ae20b72b33e5004f74889672317151:5)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.settings.biometrics.fingerprint.FingerprintEnrollSidecar.access$201(go/retraceme bb4a03fdc34cff7f722829db90aff515e0ae20b72b33e5004f74889672317151:1)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.settings.biometrics.fingerprint.FingerprintEnrollSidecar$1.onEnrollmentHelp(go/retraceme bb4a03fdc34cff7f722829db90aff515e0ae20b72b33e5004f74889672317151:3)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.settings.biometrics.fingerprint.FingerprintUpdater$NotifyingEnrollmentCallback.onEnrollmentHelp(go/retraceme bb4a03fdc34cff7f722829db90aff515e0ae20b72b33e5004f74889672317151:3)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.hardware.fingerprint.FingerprintCallback.sendAcquiredResult(FingerprintCallback.java:199)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.hardware.fingerprint.FingerprintManager$FingerprintServiceReceiver.lambda$onAcquired$1(FingerprintManager.java:1572)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.hardware.fingerprint.FingerprintManager$FingerprintServiceReceiver.$r8$lambda$wcZms5DTCBGW5VTEeJRCWEIwTW4(Unknown Source:0)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.hardware.fingerprint.FingerprintManager$FingerprintServiceReceiver$$ExternalSyntheticLambda10.run(D8$$SyntheticClass:0)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:991)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:232)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:317)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8930)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:595)
05-23 22:59:15.144 11647 11647 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)