### PR TITLE
Settings: fingerprint: Skip creating footer during enrollment on UDFPS devices

### DIFF
--- a/src/com/android/settings/biometrics/fingerprint/FingerprintEnrollEnrolling.java
+++ b/src/com/android/settings/biometrics/fingerprint/FingerprintEnrollEnrolling.java
@@ -287,21 +287,16 @@ public class FingerprintEnrollEnrolling extends BiometricsEnrollEnrolling {
         mProgressBar = findViewById(R.id.fingerprint_progress_bar);
         mVibrator = getSystemService(Vibrator.class);
 
-        mFooterBarMixin = getLayout().getMixin(FooterBarMixin.class);
-        mFooterBarMixin.setSecondaryButton(
-                new FooterButton.Builder(this)
-                        .setText(R.string.security_settings_fingerprint_enroll_enrolling_skip)
-                        .setListener(this::onSkipButtonClick)
-                        .setButtonType(FooterButton.ButtonType.SKIP)
-                        .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Secondary)
-                        .build()
-        );
-
-        // If it's udfps, set the background color only for secondary button if necessary.
-        if (mCanAssumeUdfps) {
-            mShouldSetFooterBarBackground = false;
-            ((UdfpsEnrollEnrollingView) getLayout()).setSecondaryButtonBackground(
-                    getBackgroundColor());
+        if (!mCanAssumeUdfps) {
+            mFooterBarMixin = getLayout().getMixin(FooterBarMixin.class);
+            mFooterBarMixin.setSecondaryButton(
+                    new FooterButton.Builder(this)
+                            .setText(R.string.security_settings_fingerprint_enroll_enrolling_skip)
+                            .setListener(this::onSkipButtonClick)
+                            .setButtonType(FooterButton.ButtonType.SKIP)
+                            .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Secondary)
+                            .build()
+            );
         }
 
         final LayerDrawable fingerprintDrawable = mProgressBar != null


### PR DESCRIPTION
> The new styling for the footer and footer button causes the button to be placed above the fingerprint area on devices with a low-positioned sensor. It's not needed anyway as there is a back button in the header.