### PR TITLE
Settings: Add toggle for face down detection

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -3406,6 +3406,10 @@
     <string name="screen_timeout_summary">After <xliff:g id="timeout_description">%1$s</xliff:g> of inactivity</string>
     <!-- Sound & display settings screen, setting option summary if there is no matching candidate -->
     <string name="screen_timeout_summary_not_set">Not set</string>
+    <!-- Display settings screen, setting option to toggle sleep on face down -->
+    <string name="face_down_sleep_title">Face down detection</string>
+    <!-- Display settings screen, setting option summary to toggle sleep on face down -->
+    <string name="face_down_sleep_summary">Turn off screen after a short period when device is flipped over</string>
     <!-- Wallpaper settings title [CHAR LIMIT=30] -->
     <string name="wallpaper_settings_title">Wallpaper</string>
     <!-- Styles & Wallpapers settings title [CHAR LIMIT=30] -->

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -103,10 +103,20 @@
             android:fragment="com.android.settings.display.ScreenTimeoutSettings"
             settings:controller="com.android.settings.display.ScreenTimeoutPreferenceController"/>
 
+        <org.evolution.settings.preferences.DeviceConfigSwitchPreference
+            android:key="flip_to_screen_off"
+            android:title="@string/face_down_sleep_title"
+            android:summary="@string/face_down_sleep_summary"
+            settings:deviceConfigNamespace="attention_manager_service"
+            settings:deviceConfigFlag="enable_flip_to_screen_off"
+            settings:deviceConfigDefault="true" />
+
+
         <SwitchPreferenceCompat
             android:key="pocket_judge"
             android:title="@string/proximity_wake_title"
             android:summary="@string/proximity_wake_summary" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Google has a default feature to turn off the screen when the device is flipped over but didn't expose a user setting for it

**Prerequisite**: https://github.com/Evolution-X/packages_apps_Evolver/pull/344