### PR TITLE
Settings: Move face_down_sleep strings to evolution_strings.xml

### DIFF
--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -16,6 +16,11 @@
     <string name="maintainer_link_donate">Donate</string>
     <string name="device_name">Device</string>
 
+     <!-- Display settings screen, setting option to toggle sleep on face down -->
+    <string name="face_down_sleep_title">Face down detection</string>
+    <!-- Display settings screen, setting option summary to toggle sleep on face down -->
+    <string name="face_down_sleep_summary">Turn off screen after a short period when device is flipped over</string>
+     
     <!-- Deep Sleep percentage in device info -->
     <string name="status_sleep_time">Deep sleep</string>
 


### PR DESCRIPTION
face_down_sleep_title and face_down_sleep_summary are currently in strings.xml, which is not synced with Crowdin, making these strings untranslatable.

Moving them to evolution_strings.xml allows translators to provide translations via Crowdin for all languages.